### PR TITLE
When ignoring syslog messages a stack trace is no longer printed

### DIFF
--- a/isyslog.c
+++ b/isyslog.c
@@ -219,9 +219,10 @@ mock___syslog_chk(int prio,
 	np_throw(event_t(EV_SLMATCH, msg).with_stack());
 	break;
     case SL_UNKNOWN:
-    case SL_IGNORE:
     case SL_COUNT:
 	np_raise(event_t(EV_SYSLOG, msg).with_stack());
+	break;
+    case SL_IGNORE:
 	break;
     }
 }
@@ -242,9 +243,10 @@ mock_syslog(int prio, const char *fmt, ...)
 	np_throw(event_t(EV_SLMATCH, msg).with_stack());
 	break;
     case SL_UNKNOWN:
-    case SL_IGNORE:
     case SL_COUNT:
 	np_raise(event_t(EV_SYSLOG, msg).with_stack());
+	break;
+    case SL_IGNORE:
 	break;
     }
 }

--- a/tests/tnsyslogmatch.ee
+++ b/tests/tnsyslogmatch.ee
@@ -7,7 +7,6 @@ EVENT SLMATCH err: fnarp
 FAIL tnsyslogmatch.one_message_no_matches
 EVENT SLMATCH err: fnarp
 FAIL tnsyslogmatch.one_message_unmatched
-EVENT SYSLOG err: fnarp
 PASS tnsyslogmatch.one_message_ignored
 EVENT SYSLOG err: foo bar baz
 PASS tnsyslogmatch.one_message_one_match


### PR DESCRIPTION
Previously when an ignored syslog message was detected a stack trace
would be printed even though the test would still pass.

Now nothing is displayed when an ignored syslog message is detected.