### PR TITLE
Creating a filename object with a null char* shouldn't crash

### DIFF
--- a/np/util/filename.hxx
+++ b/np/util/filename.hxx
@@ -26,7 +26,7 @@ public:
     filename_t() {}
     filename_t(const filename_t &o) : std::string(o.c_str()) {}
     filename_t(const std::string &o) : std::string(o) {}
-    filename_t(const char *s) : std::string(s) {}
+    filename_t(const char *s) : std::string(s ? s : "") {}
 
     bool is_absolute() const
     {


### PR DESCRIPTION
It is possible for a filename_t to be constructed with a null pointer
passed in.  The code should handle this gracefully.

Feel free to suggest a cleaner way of doing this if you have one.  What I see with debug enabled is filename_t is called with a char * pointing to null.