### PR TITLE
Add support for multiple format options at the same time

### DIFF
--- a/doc/manual/output-formats.rst
+++ b/doc/manual/output-formats.rst
@@ -5,7 +5,9 @@ Output Formats
 NovaProva supports two different test result output formats.  You
 can select between these using the ``--format`` option to the
 test executable, or by calling ``np_set_output_format()`` if you
-write your own ``main()`` routine.
+write your own ``main()`` routine.  If multiple formats are required
+then provide a comma separated list when using the ``--format``
+option or call ``np_set_output_format()`` multiple times.
 
 ``text``
     A simple text output format, designed to be read by humans.  Output

--- a/main.c
+++ b/main.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <getopt.h>
 #include "np/util/profile.hxx"
+#include "np/util/tok.hxx"
 
 static void
 usage(const char *argv0)
@@ -33,7 +34,7 @@ main(int argc, char **argv)
     int ec = 0;
     np_plan_t *plan = 0;
     np_runner_t *runner = 0;
-    const char *output_format = 0;
+    const char *output_formats = 0;
     enum { UNKNOWN, RUN, LIST } mode = UNKNOWN;
     int concurrency = -1;
     int c;
@@ -51,7 +52,7 @@ main(int argc, char **argv)
 	switch (c)
 	{
 	case 'f':
-	    output_format = optarg;
+	    output_formats = optarg;
 	    break;
 	case 'j':
 	    if (!strcasecmp(optarg, "max"))
@@ -85,13 +86,18 @@ main(int argc, char **argv)
     case UNKNOWN:
     case RUN:	    /* Run the specified (or all the discovered) tests */
 	/* Set the output format */
-	if (output_format)
+	if (output_formats)
 	{
-	    if (!np_set_output_format(runner, output_format))
-	    {
-		fprintf(stderr, "np: unknown output format '%s'\n", output_format);
-		exit(1);
-	    }
+		const char *format;
+		np::util::tok_t tok(output_formats, ",");
+		while ((format = tok.next()))
+		{
+			if (!np_set_output_format(runner, format))
+			{
+				fprintf(stderr, "np: unknown output format '%s'\n", output_formats);
+				exit(1);
+			}
+		}
 	}
 
 	/* Set how many tests will be run in parallel */


### PR DESCRIPTION
It is now possible to specify multiple output formats to be used in a
single run of the test suite. To specify multiple options pass in a
comma separated list of format options. For example --format junit,text