### PR TITLE
Print out filename:lineno in assert failure message

### DIFF
--- a/np/event.cxx
+++ b/np/event.cxx
@@ -208,7 +208,12 @@ string event_t::get_short_location() const
 string event_t::get_long_location() const
 {
     if (locflags & LT_STACK)
-	return string(function);
+    {
+	string s = "";
+	if ((locflags & (LT_FILENAME|LT_LINENO)) == (LT_FILENAME|LT_LINENO))
+	    s = get_short_location() + "\n";
+	return s + string(function);
+    }
     return get_short_location() + "\n";
 }
 


### PR DESCRIPTION
It is useful to identify which assert failed in a test.
As the filename and the line number are passed in and printed out
by get_short_location() of an assert event, display it along with
stack trace.