### PR TITLE
Allow a custom suppression file to be used with Valgrind

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -230,12 +230,12 @@ if test "$with_valgrind" = yes ; then
 fi
 
 AC_ARG_WITH(valgrind-suppression,
-	      [Use an additional suppression file when running Valgrind],
+	      [Path to a suppression file to use when running Valgrind],
 	      [with_valgrind_suppression=$withval],
 	      [with_valgrind_suppression=no])
 case "$with_valgrind_suppression" in
 yes)
-    SUPPRESSION_FILE="../../../np/valgrind.supp"
+    AC_MSG_ERROR([A file path to the Valgrind suppression file is mandatory])
     ;;
 no)
     ;;
@@ -246,7 +246,7 @@ no)
 esac
 
 if test "$with_valgrind_suppression" = yes ; then
-    AC_DEFINE_UNQUOTED(_NP_VALGRIND_SUPPRESSION_FILE, "$SUPPRESSION_FILE", [The Valgrind suppression file])
+    AC_DEFINE_UNQUOTED(_NP_VALGRIND_SUPPRESSION_FILE, "$SUPPRESSION_FILE", [The Valgrind suppression file path])
 fi
 
 AC_CONFIG_HEADERS([np/util/config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -230,10 +230,13 @@ if test "$with_valgrind" = yes ; then
 fi
 
 AC_ARG_WITH(valgrind-suppression,
-	      [Path to a suppression file to use when running Valgrind],
-	      [],
+	      [Use an additional suppression file when running Valgrind],
+	      [with_valgrind_suppression=$withval],
 	      [with_valgrind_suppression=no])
 case "$with_valgrind_suppression" in
+yes)
+    SUPPRESSION_FILE="../../../np/valgrind.supp"
+    ;;
 no)
     ;;
 *)
@@ -243,7 +246,7 @@ no)
 esac
 
 if test "$with_valgrind_suppression" = yes ; then
-    AC_DEFINE_UNQUOTED(_NP_VALGRIND_SUPPRESSION_FILE, "$SUPPRESSION_FILE", [The Valgrind suppression file path])
+    AC_DEFINE_UNQUOTED(_NP_VALGRIND_SUPPRESSION_FILE, "$SUPPRESSION_FILE", [The Valgrind suppression file])
 fi
 
 AC_CONFIG_HEADERS([np/util/config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -230,13 +230,10 @@ if test "$with_valgrind" = yes ; then
 fi
 
 AC_ARG_WITH(valgrind-suppression,
-	      [Use an additional suppression file when running Valgrind],
-	      [with_valgrind_suppression=$withval],
+	      [Path to a suppression file to use when running Valgrind],
+	      [],
 	      [with_valgrind_suppression=no])
 case "$with_valgrind_suppression" in
-yes)
-    SUPPRESSION_FILE="../../../np/valgrind.supp"
-    ;;
 no)
     ;;
 *)
@@ -246,7 +243,7 @@ no)
 esac
 
 if test "$with_valgrind_suppression" = yes ; then
-    AC_DEFINE_UNQUOTED(_NP_VALGRIND_SUPPRESSION_FILE, "$SUPPRESSION_FILE", [The Valgrind suppression file])
+    AC_DEFINE_UNQUOTED(_NP_VALGRIND_SUPPRESSION_FILE, "$SUPPRESSION_FILE", [The Valgrind suppression file path])
 fi
 
 AC_CONFIG_HEADERS([np/util/config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -229,6 +229,26 @@ if test "$with_valgrind" = yes ; then
     PKG_CHECK_MODULES(valgrind, valgrind)
 fi
 
+AC_ARG_WITH(valgrind-suppression,
+	      [Use an additional suppression file when running Valgrind],
+	      [with_valgrind_suppression=$withval],
+	      [with_valgrind_suppression=no])
+case "$with_valgrind_suppression" in
+yes)
+    SUPPRESSION_FILE="../../../np/valgrind.supp"
+    ;;
+no)
+    ;;
+*)
+	SUPPRESSION_FILE="$withval"
+	with_valgrind_suppression=yes
+    ;;
+esac
+
+if test "$with_valgrind_suppression" = yes ; then
+    AC_DEFINE_UNQUOTED(_NP_VALGRIND_SUPPRESSION_FILE, "$SUPPRESSION_FILE", [The Valgrind suppression file])
+fi
+
 AC_CONFIG_HEADERS([np/util/config.h])
 AC_CONFIG_FILES([
     Makefile

--- a/np.c
+++ b/np.c
@@ -57,8 +57,10 @@ be_valground(void)
     *p++ = VALGRIND_BINARY;
     *p++ = "-q";
     *p++ = "--tool=memcheck";
-//     *p++ = "--leak-check=full";
-//     *p++ = "--suppressions=../../../np/valgrind.supp";
+#ifdef _NP_VALGRIND_SUPPRESSION_FILE
+    *p++ = "--gen-suppressions=all";
+    *p++ = "--suppressions="_NP_VALGRIND_SUPPRESSION_FILE;
+#endif
     while (*argv)
 	*p++ = *argv++;
 


### PR DESCRIPTION
Defaults to off, and if the user only enables it and doesn't supply a
file path then it will default to valgrind.supp in the base of the
Novaprova repo (this is what is currently commented out in np.c).