### PR TITLE
Don't print stack trace when syslog message is expected

### DIFF
--- a/isyslog.c
+++ b/isyslog.c
@@ -219,9 +219,9 @@ mock___syslog_chk(int prio,
 	np_throw(event_t(EV_SLMATCH, msg).with_stack());
 	break;
     case SL_UNKNOWN:
-    case SL_COUNT:
 	np_raise(event_t(EV_SYSLOG, msg).with_stack());
 	break;
+    case SL_COUNT:
     case SL_IGNORE:
 	break;
     }
@@ -243,9 +243,9 @@ mock_syslog(int prio, const char *fmt, ...)
 	np_throw(event_t(EV_SLMATCH, msg).with_stack());
 	break;
     case SL_UNKNOWN:
-    case SL_COUNT:
 	np_raise(event_t(EV_SYSLOG, msg).with_stack());
 	break;
+    case SL_COUNT:
     case SL_IGNORE:
 	break;
     }


### PR DESCRIPTION
Currently if a syslog message is configured to be ignored no stack
trace is printed. However, when we are expecting a syslog message
and want to count how many times it is printed (via np_syslog_match)
a stack trace is also printed. This can make the output quite messy
(if a lot of syslog messages are being counted) and can easily be
confused for an unexpected syslog message which also prints a stack
trace and fails the test.

For simplicity and to improve the test output it seems best to simply
not print a stack trace for counted syslog messages, similar to ignored
messages.