### PR TITLE
Add cast to avoid warning

### DIFF
--- a/np/event.cxx
+++ b/np/event.cxx
@@ -89,7 +89,7 @@ event_t::normalise() const
     static string filebuf;
     static string funcbuf;
 
-    memset(&norm, 0, sizeof(norm));
+    memset(static_cast<void *>(&norm), 0, sizeof(norm));
     norm.which = which;
     norm.description = xstr(description);
 


### PR DESCRIPTION
GCC 8.3 complains

 np/event.cxx: In member function 'const np::event_t* np::event_t::normalise() const':
 np/event.cxx:92:34: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'class np::event_t'; use assignment or value-initialization instead [-Werror=class-memaccess]
      memset(&norm, 0, sizeof(norm));
                                   ^
 In file included from np/event.cxx:16:
 ./np/event.hxx:43:7: note: 'class np::event_t' declared here
  class event_t
        ^~~~~~~

Add a cast to suppress the warning

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>