### PR TITLE
spiegel/dwarf: ignore files in /lib64

### DIFF
--- a/np/spiegel/dwarf/state.cxx
+++ b/np/spiegel/dwarf/state.cxx
@@ -254,6 +254,7 @@ filename_is_ignored(const char *filename)
     {
 	"/bin/",
 	"/lib/",
+	"/lib64/",
 	"/usr/bin/",
 	"/usr/lib/",
 	"/opt/",


### PR DESCRIPTION
On some systems ld.so.2 ends up in /lib64 (e.g. for debian x86_64 it's
/lib64/ld-linux-x86-64.so.2). Add /lib64 to the list of prefixes to
ignore.

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>