### PR TITLE
Fix assert on test timeout

### DIFF
--- a/np/runner.hxx
+++ b/np/runner.hxx
@@ -54,7 +54,7 @@ private:
     /* Wait for and reap the child process specified by pid.  If pid is -1,
      * reaps any child processes.  If waitflags contains WNOHANG, do not
      * wait for child processes to exit. */
-    void reap_children(pid_t pid, int waitflags);
+    int reap_children(pid_t pid, int waitflags);
     void run_function(functype_t ft, spiegel::function_t *f);
     void run_fixtures(testnode_t *tn, functype_t type);
     result_t valgrind_errors(job_t *, result_t);


### PR DESCRIPTION
When a test times out, sigterm is sent to it to kill the process. This causes a SIGCHILD to show up in the wait polling, which triggers novaprova to clean up the test. However, this test was not being recorded as finished, so the wait loop could not exit. This caused an assert on the next loop through the loop which prevented the results of the test run from being recorded (via junit). This made it difficult to see if other tests in the test run were also suffering from performance issues or just the test that timed out.

This patch correctly marks the test as finished after the child process is terminated and changes reap_children to return the number of processes that were ended. This allows the wait function to successfully exit as it keeps going till something finishes.

Signed-off-by: Luuk Paulussen <luuk.paulussen@alliedtelesis.co.nz>